### PR TITLE
Fix starts_with option overwriting

### DIFF
--- a/tests/units/get-languages.test.js
+++ b/tests/units/get-languages.test.js
@@ -9,11 +9,11 @@ describe('getLanguages function', () => {
     expect(getLanguages([])).toEqual([''])
   })
 
-  test("getLanguages(['pt']) should be ['pt/*', '']", () => {
-    expect(getLanguages(['pt'])).toEqual(['pt/*', ''])
+  test("getLanguages(['pt']) should be ['pt/', '']", () => {
+    expect(getLanguages(['pt'])).toEqual(['pt/', ''])
   })
 
-  test("getLanguages(['pt', 'de']) should be ['pt/*', 'de/*', '']", () => {
-    expect(getLanguages(['pt', 'de'])).toEqual(['pt/*', 'de/*', ''])
+  test("getLanguages(['pt', 'de']) should be ['pt/', 'de/', '']", () => {
+    expect(getLanguages(['pt', 'de'])).toEqual(['pt/', 'de/', ''])
   })
 })

--- a/utils/get-client-options.js
+++ b/utils/get-client-options.js
@@ -6,7 +6,7 @@
  */
 const getClientOptions = (language = '', options = {}) => {
   if (language.length > 0) {
-    options.starts_with = language
+    options.starts_with = language + (options.starts_with || '')
   }
 
   return options

--- a/utils/get-languages.js
+++ b/utils/get-languages.js
@@ -5,7 +5,7 @@
  */
 const getLanguages = (codes = []) => {
   return [
-    ...codes.map(lang => lang + '/*'),
+    ...codes.map(lang => lang + '/'),
     '' // default languages does not need transform path
   ]
 }


### PR DESCRIPTION
This PR prevents the following incorrect behavior: when we use the `params` option with `starts_with` field in plugin configuration, the `getClientOptions` function ignore this field, replacing with the language passed as argument. So, this PR changes this function preventing this overwrite, concatenating the previous starts_with with the language.

The following code snippet explain the before and after behaviors:

```js
const option = {
  starts_with: 'blog/'
}

// previous behavior
getClientOptions('pt/', option) // returns { starts_with: 'pt/' }

// later behavior
getClientOptions('pt/', option) // returns { starts_with: 'pt/blog/' }
```